### PR TITLE
Fix qrcode dependency name, add pip3 installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ Tools:
 
 ## Requirements:
  - `andotp_decrypt.py`: Python 3 and pycrypto
- - `generate_qr_codes.py` + `generate_code.py`: pyqrcode and pyotp
+ - `generate_qr_codes.py` + `generate_code.py`: qrcode[pil] and pyotp
 
 On debian/ubuntu this should work:
  - `sudo apt-get install python3-crypto python3-pyotp python3-qrcode`
+
+To install with pip, use:
+ - `sudo pip3 install pycrypto qrcode[pil] pyotp`
 
 ## Usage:
  - Dump JSON to the console:


### PR DESCRIPTION
First off: thanks for making these tools! They're very handy.
When I first tried to get the three Python scripts to run, I ran into dependency issues. I installed `pyqrcode` with `pip3`, but found that I needed the `qrcode[pil]` module instead.

I edited the README to reflect this change from `pyqrcode` -> `qrcode[pil]`. I also added instructions for installing the dependencies using `pip3` for users that aren't using a debian-based system.