### PR TITLE
Add flag for displaying all matches for the given label search string

### DIFF
--- a/generate_code.py
+++ b/generate_code.py
@@ -2,9 +2,10 @@
 """generate_code.py
 
 Usage:
-  generate_code.py ANDOTP_AES_BACKUP_FILE MATCH_STRING
+  generate_code.py [-a] ANDOTP_AES_BACKUP_FILE MATCH_STRING
 
 Options:
+  -a --all      Show all matches.
   -h --help     Show this screen.
   --version     Show version.
 
@@ -25,15 +26,21 @@ if __name__ == '__main__':
         sys.exit(1)
     entries = json.loads(text)
 
+    found = False
     for entry in entries:
         label = entry['label']
         if entry['type'] == 'TOTP':
-            if arguments["MATCH_STRING"].lower() in label.lower(): 
+            if arguments["MATCH_STRING"].lower() in label.lower():
+                found = True
                 totp = pyotp.TOTP(entry['secret'], interval=entry['period'])
                 print("Matched: %s" % label)
                 print(totp.now())
-                sys.exit(0)
+                if not arguments["--all"]:
+                    # The all flag wasn't provided, i.e. we only wanted one
+                    # match, so we can exit.
+                    sys.exit(0)
         else:
             print("Unsupported OTP type: %s" % entry["type"])
             sys.exit(2)
-    print("No entry matching '%s' found" % arguments["MATCH_STRING"])
+    if not found:
+        print("No entry matching '%s' found" % arguments["MATCH_STRING"])


### PR DESCRIPTION
While generating codes, it's nice to have the option to show all matches for the given search string. This means that if someone has multiple Google accounts, all with "Google:\<name\>@gmail.com" as the label, they can just search "Google"; they'll receive the code for their desired account, without having to manually specify more of their address.