### PR TITLE
Migrate from pycrypto to pycryptodome

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Tools:
  - `generate_code.py`: A tool to generate a TOTP token for an account in the backup
 
 ## Requirements:
- - `andotp_decrypt.py`: Python 3 and pycrypto
+ - `andotp_decrypt.py`: Python 3 and pycryptodome
  - `generate_qr_codes.py` + `generate_code.py`: pyqrcode and pyotp
 
 On debian/ubuntu this should work:
- - `sudo apt-get install python3-crypto python3-pyotp python3-qrcode`
+ - `sudo apt-get install python3-cryptodome python3-pyotp python3-qrcode`
 
 ## Usage:
  - Dump JSON to the console:

--- a/andotp_decrypt.py
+++ b/andotp_decrypt.py
@@ -10,7 +10,7 @@ Options:
 
 """
 
-from aes_gcm.aes_gcm import AES_GCM, InvalidTagException
+from Crypto.Cipher import AES
 from Crypto.Hash import SHA256
 from os.path import basename
 from getpass import getpass
@@ -44,10 +44,14 @@ def decrypt_aes(input_file):
         print("IV: %s" % bytes2Hex(iv))
         print("Crypttext: %s" % bytes2Hex(crypttext))
         print("Auth tag: %s" % bytes2Hex(tag))
-
-    aes = AES_GCM(symmetric_key)
     try:
-        dec = aes.decrypt(iv, crypttext, tag)
+        aes = AES.new(symmetric_key, AES.MODE_GCM, nonce=iv)
+    except AttributeError as e:
+        print(e)
+        print('Using \'pycryptodome\' instead of \'pycrypto\' should solve this issue.')
+        sys.exit(1)
+    try:
+        dec = aes.decrypt_and_verify(crypttext, tag)
         if debug:
             print("Decrypted data: %s" % bytes2Hex(dec))
         return dec.decode('UTF-8')


### PR DESCRIPTION
Apparently ```pycryptodome``` is now widely preferred and one would get rid of the ```aes_gcm``` folder.
I did this because the implementation in ```aes_gcm``` for some reason did not really work for me.