### PR TITLE
Fix empty input error

### DIFF
--- a/andotp_decrypt.py
+++ b/andotp_decrypt.py
@@ -55,17 +55,20 @@ def decrypt_aes_new_format(password, input_file, debug=False):
     with open(input_file, 'rb') as f:
         input_bytes = f.read()
 
-    # Raw data structure is iterations[:4] + salt[4:16] + data[16:]
-    iterations = struct.unpack(">I", input_bytes[:4])[0]
-    salt       = input_bytes[4:16]
-    data       = input_bytes[16:]
-    pbkdf2_key = hashlib.pbkdf2_hmac('sha1', password, salt, iterations, 32)
-    if debug:
-        print("Iterations: %s" % iterations)
-        print("Salt: %s" % bytes2Hex(salt))
-        print("Pbkdf2 key: %s" % bytes2Hex(pbkdf2_key))
-
-    return decode(pbkdf2_key, data, debug)
+    try:
+        # Raw data structure is iterations[:4] + salt[4:16] + data[16:]
+        iterations = struct.unpack(">I", input_bytes[:4])[0]
+        salt       = input_bytes[4:16]
+        data       = input_bytes[16:]
+        pbkdf2_key = hashlib.pbkdf2_hmac('sha1', password, salt, iterations, 32)
+        if debug:
+            print("Iterations: %s" % iterations)
+            print("Salt: %s" % bytes2Hex(salt))
+            print("Pbkdf2 key: %s" % bytes2Hex(pbkdf2_key))
+        return decode(pbkdf2_key, data, debug)
+    except struct.error:
+        print("The input file is probably empty")
+        return None
 
 def decrypt_aes(password, input_file, debug=False):
     hash = SHA256.new(password)

--- a/andotp_decrypt.py
+++ b/andotp_decrypt.py
@@ -38,8 +38,12 @@ def decode(key, data, debug=False):
         print("IV: %s" % bytes2Hex(iv))
         print("Crypttext: %s" % bytes2Hex(crypttext))
         print("Auth tag: %s" % bytes2Hex(tag))
+    try:
+        aes = AES.new(key, AES.MODE_GCM, nonce=iv)
+    except Exception as e:
+        print(e)
+        return None
 
-    aes = AES.new(key, AES.MODE_GCM, nonce=iv)
     try:
         dec = aes.decrypt_and_verify(crypttext, tag)
         if debug:

--- a/generate_code.py
+++ b/generate_code.py
@@ -29,7 +29,8 @@ def main():
         text = andotp_decrypt.decrypt_aes_new_format(password, arguments['ANDOTP_AES_BACKUP_FILE'])
 
     if not text:
-        print("Something went wrong while loading %s. Maybe the passphrase was wrong?" % arguments['ANDOTP_AES_BACKUP_FILE'])
+        print("Something went wrong while loading %s. Maybe the passphrase was wrong" \
+                " or the input file is empty!" % arguments['ANDOTP_AES_BACKUP_FILE'])
         sys.exit(1)
     entries = json.loads(text)
 

--- a/generate_qr_codes.py
+++ b/generate_qr_codes.py
@@ -29,7 +29,8 @@ def main():
         text = andotp_decrypt.decrypt_aes_new_format(password, arguments['ANDOTP_AES_BACKUP_FILE'])
 
     if not text:
-        print("Something went wrong while loading %s. Maybe the passphrase was wrong?" % arguments['ANDOTP_AES_BACKUP_FILE'])
+        print("Something went wrong while loading %s. Maybe the passphrase was wrong?" 
+                " or the input file is empty!" % arguments['ANDOTP_AES_BACKUP_FILE'])
         sys.exit(1)
     entries = json.loads(text)
     for entry in entries:

--- a/testdata/test.sh
+++ b/testdata/test.sh
@@ -7,3 +7,7 @@ echo 123456 | python ../generate_qr_codes.py accounts_new_123456.json.aes
 echo 123456 | python ../andotp_decrypt.py -o accounts_old_123456.json.aes
 echo 123456 | python ../generate_code.py -o accounts_old_123456.json.aes test
 echo 123456 | python ../generate_qr_codes.py -o accounts_old_123456.json.aes
+
+echo 123456 | python ../andotp_decrypt.py emptyfile.json.aes
+echo 123456 | python ../generate_code.py emptyfile.json.aes test
+echo 123456 | python ../generate_qr_codes.py emptyfile.json.aes


### PR DESCRIPTION
I (unintentionally) tried to use andotp-decrypt.py with a backup file from andOTP that did not sync properly and was empty. I got some messages that did not point explicitly to the problem until I looked at the input file with `du` to find the file was empty.

So I added error handling for decrypt_aes() and decrypt_aes_new_format() when the input file is empty. 