### PR TITLE
svg-files are stored under their issuer-name, instead of label

### DIFF
--- a/generate_qr_codes.py
+++ b/generate_qr_codes.py
@@ -36,9 +36,17 @@ def main():
     for entry in entries:
         url = None
         issuer = None
+        try:
+            issuer = entry['issuer']
+        except:
+            pass
+
         label = entry['label']
-        if " - " in label:
-            issuer, label = label.split(" - ", 1)
+        if issuer == None:
+            if " - " in label:
+                issuer, label = label.split(" - ", 1)
+            else:
+                issuer = label
         if entry['type'] == 'TOTP':
             totp = pyotp.TOTP(entry['secret'], interval=entry['period'])
             url = totp.provisioning_uri(label, issuer_name = issuer)
@@ -47,7 +55,7 @@ def main():
             url = totp.provisioning_uri(label, issuer_name = issuer)
         if url:
             img = pyqrcode.create(url)
-            save_filename = "".join([c for c in label if c.isalpha() or c.isdigit() or c in "@_-"]).strip() + ".svg"
+            save_filename = "".join([c for c in issuer if c.isalpha() or c.isdigit() or c in "@_-"]).strip() + ".svg"
             img.svg(save_filename, scale=4, background='#fff')
             print("Code saved as: %s" % save_filename)
 


### PR DESCRIPTION
I've had the problem, that some TOTP-tokens had the same label. The label had no "-" in them, so some of the SVGs were overwritten. But I saw, that the TOTP-tokens had an issuer. 

With this PR the behaviour should stay the same, if there was no issuer, but if there is, it is used as the file names. To be even more sure, one could also detect existing files and hang on a hash or something.