### PR TITLE
Update to use from pycryptodome AES instead of pycrpto version as CCM…

### DIFF
--- a/andotp_decrypt.py
+++ b/andotp_decrypt.py
@@ -18,7 +18,7 @@ import hashlib
 import struct
 from getpass import getpass
 
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 from Crypto.Hash import SHA256
 
 from docopt import docopt


### PR DESCRIPTION
… is no longer present

As python3-pycryptodome was already part of the install dependencies it seems maybe this was forgotten or python 3.8 on Ubuntu 20.04 based distros caused it to break.

Otherwise it throws a 

 module 'Crypto.Cipher.AES' has no attribute 'MODE_GCM'

Error and exits after the password is entered.